### PR TITLE
Add support for Juju 3.4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,6 +10,10 @@ on:
       - "**.md"
       - "**.rst"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2
@@ -19,19 +23,16 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: "<4"
       working-directory: ./src
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - juju-channel: "3.1/stable"
-            command: "make functional"
-            runs-on: "['self-hosted', 'xlarge', 'jammy', 'x64']"
+        command: ['TEST_JUJU3=1 make functional']  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+        juju-channel: ['3.4/stable']
     with:
       command: ${{ matrix.command }}
       juju-channel: ${{ matrix.juju-channel }}
@@ -39,4 +40,3 @@ jobs:
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
-      tox-version: "<4"

--- a/src/tests/functional/requirements.txt
+++ b/src/tests/functional/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza
+git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
 python-openstackclient

--- a/src/tests/functional/requirements.txt
+++ b/src/tests/functional/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/rgildein/zaza.git@chore/no-ref/fix-action-object#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 python-openstackclient

--- a/src/tests/functional/tests/bundles/base.yaml
+++ b/src/tests/functional/tests/bundles/base.yaml
@@ -1,5 +1,6 @@
 applications:
   prometheus-blackbox-exporter:
+    charm: prometheus-blackbox-exporter
     options:
       snap_channel: stable
     num_units: 1

--- a/src/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/src/tests/functional/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,3 +1,3 @@
 applications:
-  prometheus-blackbox-exporter:
+  {{ charm_name }}:
     charm: "{{ CHARM_LOCATION }}/{{ charm_name }}.charm"

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -14,6 +14,7 @@ passenv =
   OS_*
   CHARM_*
   ZAZA_*
+  TEST_*
   PYTEST_KEEP_MODEL
   PYTEST_CLOUD_NAME
   PYTEST_CLOUD_REGION
@@ -67,5 +68,5 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
-commands = functest-run-suite --keep-faulty-model {posargs}
+commands = functest-run-suite {posargs:--keep-faulty-model}
 deps = -r{toxinidir}/tests/functional/requirements.txt


### PR DESCRIPTION
Add TEST_JUJU3 for zaza usage and fix overlays issue.

Dropping self-hosted runner, since it's not need and with that switch back to bootstack-actions v2.

Add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.

~~Blocked until [#655](https://github.com/openstack-charmers/zaza/pull/655) is merged.~~